### PR TITLE
contentsID -> contentsId

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3,7 +3,7 @@ Title: The TODO API
 Shortname: todo
 Level: None
 Status: w3c/UD
-Repository: explainers-by-googlers/todo-your-repo-name
+Repository: explainers-by-googlers/clipboard-contents-id
 URL: https://explainers-by-googlers.github.io/todo-your-repo-name
 Editor: Luke Klimek, Google https://google.com, zgroza@google.com
 Abstract: An API for getting a unique ID of current clipboard contents.
@@ -20,7 +20,7 @@ Include Can I Use Panels: yes
 Introduction {#intro}
 =====================
 
-For now, see the [explainer]([REPOSITORYURL]).
+For now, see the [explainer](https://github.com/explainers-by-googlers/clipboard-contents-id).
 
 See [https://garykac.github.io/procspec/](https://garykac.github.io/procspec/),
 [https://dlaliberte.github.io/bikeshed-intro/index.html](https://dlaliberte.github.io/bikeshed-intro/index.html),


### PR DESCRIPTION
Fixes https://github.com/explainers-by-googlers/clipboard-contents-id/issues/3


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zgroza/clipboard-contents-id/pull/4.html" title="Last updated on Jan 28, 2025, 4:22 PM UTC (2a72443)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/explainers-by-googlers/clipboard-contents-id/4/e9ed040...zgroza:2a72443.html" title="Last updated on Jan 28, 2025, 4:22 PM UTC (2a72443)">Diff</a>